### PR TITLE
Serializable objects

### DIFF
--- a/lib/php_serializable.ex
+++ b/lib/php_serializable.ex
@@ -1,0 +1,5 @@
+defmodule PhpSerializable do
+  @moduledoc false
+
+  defstruct class: nil, data: nil
+end

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -7,6 +7,10 @@ defmodule PhpSerializer do
 
   def serialize(false), do: "b:0;"
 
+  def serialize(%PhpSerializable{ class: class, data: data}) do
+    ~s(C:#{byte_size(class)}:"#{class}":#{byte_size(data)}:{#{data}})
+  end
+
   def serialize(val) when is_integer(val), do: "i:#{val};"
 
   def serialize(val) when is_float(val) do

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -76,6 +76,16 @@ defmodule PhpSerializer do
     { value, rslt_rest }
   end
 
+  defp unserialize_value("C:" <> rest, _opts) do
+    { classname_len, rest2 } = Integer.parse(rest)
+    <<":\"", classname::binary-size(classname_len), "\":", rest3::binary>> = rest2
+    { data_len, rest4 } = Integer.parse(rest3)
+    <<":{", data::binary-size(data_len), "}", rest5::binary>> = rest4
+
+    { %PhpSerializable{class: classname, data: data}, rest5 }
+  end
+
+
   defp unserialize_value("a:" <> rest, opts) do
     { array_size, new_rest } = Integer.parse(rest)
 

--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -69,6 +69,10 @@ defmodule PhpSerializerTest do
     assert unserialize("N;i:0;") == { :error, "left extra characters: 'i:0;'" }
   end
 
+  test "unserialize serializable object" do
+    assert unserialize(~S(C:3:"obj":23:{s:15:"My private data";})) == { :ok, %PhpSerializable{ class: "obj", data: ~S(s:15:"My private data";)} }
+  end
+
   @tag method: "serialize"
 
   test "serialize null" do

--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -73,6 +73,10 @@ defmodule PhpSerializerTest do
     assert unserialize(~S(C:3:"obj":23:{s:15:"My private data";})) == { :ok, %PhpSerializable{ class: "obj", data: ~S(s:15:"My private data";)} }
   end
 
+  test "unserialize serializable object with namespace" do
+    assert unserialize(~S(C:19:"Namespace\Classname":8:{somedata})) == { :ok, %PhpSerializable{ class: "Namespace\\Classname", data: "somedata"} }
+  end
+
   @tag method: "serialize"
 
   test "serialize null" do

--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -150,4 +150,8 @@ defmodule PhpSerializerTest do
   test "serialize tuple" do
     assert serialize({4,5}) == ~S(a:2:{i:0;i:4;i:1;i:5;})
   end
+
+  test "serialize serializable" do
+    assert serialize(%PhpSerializable{class: "NameOfTheClass", data: "somedata"}) == ~S(C:14:"NameOfTheClass":8:{somedata})
+  end
 end


### PR DESCRIPTION
support for objects implementing the Serializable interface

http://ch1.php.net/manual/en/class.serializable.php

The actual data cannot be (un)serialized, as it depends on the actual implementation of the serialization in the PHP class. But if this implementation is known for a given class, then data can be serialized before or unserialized after using the PhpSerializer module.

I only wrote minimal tests (happy flow) but that should hopefully be enough for a start.