### PR TITLE
Add Object parsing

### DIFF
--- a/lib/php_serializable.ex
+++ b/lib/php_serializable.ex
@@ -1,5 +1,5 @@
 defmodule PhpSerializable do
   @moduledoc false
 
-  defstruct class: nil, data: nil
+  defstruct class: nil, data: nil, object: nil
 end

--- a/lib/php_serializable.ex
+++ b/lib/php_serializable.ex
@@ -1,5 +1,11 @@
 defmodule PhpSerializable do
   @moduledoc false
 
-  defstruct class: nil, data: nil, object: nil
+  defmodule Class do
+    defstruct class: nil, data: nil
+  end
+
+  defmodule Object do
+    defstruct class: nil, data: nil
+  end
 end

--- a/lib/php_serializable_object.ex
+++ b/lib/php_serializable_object.ex
@@ -1,0 +1,5 @@
+defmodule PhpSerializable.Object do
+  @moduledoc false
+
+  defstruct class: nil, data: nil, object: true
+end

--- a/lib/php_serializable_object.ex
+++ b/lib/php_serializable_object.ex
@@ -1,5 +1,0 @@
-defmodule PhpSerializable.Object do
-  @moduledoc false
-
-  defstruct class: nil, data: nil, object: true
-end

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -23,7 +23,7 @@ defmodule PhpSerializer do
   end
 
   def serialize(%PhpSerializable.Object{ class: class, data: data}) do
-    ~s(O:#{byte_size(class)}:"#{class}":#{byte_size(data)}:{#{serialize_object(data)}})
+    ~s(O:#{byte_size(class)}:"#{class}":#{length(data)}:{#{serialize_object(data)}})
   end
 
   def serialize(val) when is_integer(val), do: "i:#{val};"

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -132,7 +132,7 @@ defmodule PhpSerializer do
   defp unserialize_value("O:" <> rest, _opts) do
     { classname_len, rest2 } = Integer.parse(rest)
     <<":\"", classname::binary-size(classname_len), "\":", rest3::binary>> = rest2
-    val = unserialize_value("a:"<>rest3<>"}", [])
+    val = unserialize_value("a:"<>rest3, [])
     { %PhpSerializable.Object{class: classname, data: val}, ""}
   end
 

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -17,7 +17,7 @@ defmodule PhpSerializer do
 
   def serialize(false), do: "b:0;"
 
-  def serialize(%PhpSerializable{ class: class, data: data}) do
+  def serialize(%PhpSerializable{ class: class, data: data, object: false}) do
     ~s(C:#{byte_size(class)}:"#{class}":#{byte_size(data)}:{#{data}})
   end
 

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -21,8 +21,8 @@ defmodule PhpSerializer do
     ~s(C:#{byte_size(class)}:"#{class}":#{byte_size(data)}:{#{data}})
   end
 
-  def serialize(%PhpSerializable.Object{ class: class, data: data, object: true}) when is_map(data) do
-    ~s(O:#{byte_size(class)}:"#{class}":#{length(Map.keys(data))}:{#{data}})
+  def serialize(%PhpSerializable.Object{ class: class, data: data, object: true}) when is_list(data) do
+    ~s(O:#{byte_size(class)}:"#{class}":#{length(data)}:{#{data}})
   end
 
   def serialize(val) when is_integer(val), do: "i:#{val};"

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -126,22 +126,18 @@ defmodule PhpSerializer do
     <<":\"", classname::binary-size(classname_len), "\":", rest3::binary>> = rest2
     { data_len, rest4 } = Integer.parse(rest3)
     <<":{", data::binary-size(data_len), "}", rest5::binary>> = rest4
-
-    { %PhpSerializable.Class{class: classname, data: data}, rest5 }
+    { %PhpSerializable.Class{class: classname, data: data}, rest5}
   end
 
   defp unserialize_value("O:" <> rest, _opts) do
     { classname_len, rest2 } = Integer.parse(rest)
     <<":\"", classname::binary-size(classname_len), "\":", rest3::binary>> = rest2
-    { data_len, rest4 } = Integer.parse(rest3)
-    <<":{", data::binary-size(data_len), "}", rest5::binary>> = rest4
-
-    { %PhpSerializable.Object{class: classname, data: data}, rest5 }
+    val = unserialize_value("a:"<>rest3<>"}", [])
+    { %PhpSerializable.Object{class: classname, data: val}, ""}
   end
 
   defp unserialize_value("a:" <> rest, opts) do
     { array_size, new_rest } = Integer.parse(rest)
-
     unserialize_array(new_rest, array_size, opts)
   end
 

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -21,7 +21,7 @@ defmodule PhpSerializer do
     ~s(C:#{byte_size(class)}:"#{class}":#{byte_size(data)}:{#{data}})
   end
 
-  def serialize(%PhpSerializable.Object{ class: class, data: data, object: true}) when is_list(data) do
+  def serialize(%PhpSerializable{ class: class, data: data, object: true}) when is_list(data) do
     ~s(O:#{byte_size(class)}:"#{class}":#{length(data)}:{#{data}})
   end
 

--- a/lib/php_serializer.ex
+++ b/lib/php_serializer.ex
@@ -21,6 +21,10 @@ defmodule PhpSerializer do
     ~s(C:#{byte_size(class)}:"#{class}":#{byte_size(data)}:{#{data}})
   end
 
+  def serialize(%PhpSerializable.Object{ class: class, data: data, object: true}) when is_map(data) do
+    ~s(O:#{byte_size(class)}:"#{class}":#{length(Map.keys(data))}:{#{data}})
+  end
+
   def serialize(val) when is_integer(val), do: "i:#{val};"
 
   def serialize(val) when is_float(val) do

--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -81,7 +81,7 @@ defmodule PhpSerializerTest do
   end
 
   test "unserialize serializable object with namespace" do
-    assert unserialize(~S(O:14:"NameOfTheClass":7:{{a,s},d}))== { :ok, %PhpSerializable.Object{ class: "NameOfTheClass", data: "{a,s},d"} }
+    assert unserialize(~S(O:14:"NameOfTheClass":2:{s:7:"country";s:2:"ZZ";))== { :ok, %PhpSerializable.Object{ class: "NameOfTheClass", data: "{a,s},d"} }
   end
 
   @tag method: "serialize"

--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -73,11 +73,15 @@ defmodule PhpSerializerTest do
   end
 
   test "unserialize serializable object" do
-    assert unserialize(~S(C:3:"obj":23:{s:15:"My private data";})) == { :ok, %PhpSerializable{ class: "obj", data: ~S(s:15:"My private data";)} }
+    assert unserialize(~S(C:3:"obj":23:{s:15:"My private data";})) == { :ok, %PhpSerializable.Class{ class: "obj", data: ~S(s:15:"My private data";)} }
+  end
+
+  test "unserialize serializable class with namespace" do
+    assert unserialize(~S(C:19:"Namespace\Classname":8:{somedata})) == { :ok, %PhpSerializable.Class{ class: "Namespace\\Classname", data: "somedata"} }
   end
 
   test "unserialize serializable object with namespace" do
-    assert unserialize(~S(C:19:"Namespace\Classname":8:{somedata})) == { :ok, %PhpSerializable{ class: "Namespace\\Classname", data: "somedata"} }
+    assert unserialize(~S(O:14:"NameOfTheClass":7:{{a,s},d}))== { :ok, %PhpSerializable.Object{ class: "NameOfTheClass", data: "{a,s},d"} }
   end
 
   @tag method: "serialize"
@@ -154,7 +158,11 @@ defmodule PhpSerializerTest do
     assert serialize({4,5}) == ~S(a:2:{i:0;i:4;i:1;i:5;})
   end
 
-  test "serialize serializable" do
-    assert serialize(%PhpSerializable{class: "NameOfTheClass", data: "somedata"}) == ~S(C:14:"NameOfTheClass":8:{somedata})
+  test "serialize serializable Class" do
+    assert serialize(%PhpSerializable.Class{class: "NameOfTheClass", data: "somedata"}) == ~S(C:14:"NameOfTheClass":8:{somedata})
+  end
+
+  test "serialize serializable Object" do
+    assert serialize(%PhpSerializable.Object{class: "NameOfTheClass", data: "somedata"}) == ~S(O:14:"NameOfTheClass":8:{somedata})
   end
 end

--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -81,7 +81,7 @@ defmodule PhpSerializerTest do
   end
 
   test "unserialize serializable object with namespace" do
-    assert unserialize(~S(O:14:"NameOfTheClass":2:{s:7:"country";s:2:"ZZ";))== { :ok, %PhpSerializable.Object{ class: "NameOfTheClass", data: "{a,s},d"} }
+    assert unserialize(~S(O:14:"NameOfTheClass":2:{i:0;s:7:"country";i:1;s:2:"ZZ";}})) == {:ok, %PhpSerializable.Object{class: "NameOfTheClass", data: {[{0, "country"}, {1, "ZZ"}], "}"}}}
   end
 
   @tag method: "serialize"
@@ -163,6 +163,6 @@ defmodule PhpSerializerTest do
   end
 
   test "serialize serializable Object" do
-    assert serialize(%PhpSerializable.Object{class: "NameOfTheClass", data: "somedata"}) == ~S(O:14:"NameOfTheClass":8:{somedata})
+    assert serialize(%PhpSerializable.Object{class: "NameOfTheClass", data: ["somedata", 1]}) == ~S(O:14:"NameOfTheClass":2:{i:0;s:8:"somedata";i:1;i:1;}})
   end
 end


### PR DESCRIPTION
This PR adds PhpSerialzable.Class and PhpSerializable.Object modules. The Object module allows PHP objects and attributes to be processed. Appropriate functions and tests have been added.