### PR TITLE
Option to ignore excess data when unserializing

### DIFF
--- a/test/php_serializer_test.exs
+++ b/test/php_serializer_test.exs
@@ -5,83 +5,97 @@ defmodule PhpSerializerTest do
   @tag method: "unserialize"
 
   test "unserialize null" do
-    assert unserialize("N;") == { :ok, nil }
+    assert unserialize("N;") == {:ok, nil}
   end
 
   test "unserialize boolean true" do
-    assert unserialize("b:1;") == { :ok, true }
+    assert unserialize("b:1;") == {:ok, true}
   end
 
   test "unserialize boolean false" do
-    assert unserialize("b:0;") == { :ok, false }
+    assert unserialize("b:0;") == {:ok, false}
   end
 
   test "unserialize number" do
-    assert unserialize("i:123;") == { :ok, 123 }
+    assert unserialize("i:123;") == {:ok, 123}
   end
 
   test "unserialize negative number" do
-    assert unserialize("i:-321;") == { :ok, -321 }
+    assert unserialize("i:-321;") == {:ok, -321}
   end
 
   test "unserialize float" do
-    assert unserialize("d:1.5;") == { :ok, 1.5 }
+    assert unserialize("d:1.5;") == {:ok, 1.5}
   end
 
   test "unserialize negative float" do
-    assert unserialize("d:-2.5;") == { :ok, -2.5 }
+    assert unserialize("d:-2.5;") == {:ok, -2.5}
   end
 
   test "unserialize big float" do
-    assert unserialize("d:2.1E+17;") == { :ok, 2.1e17 }
+    assert unserialize("d:2.1E+17;") == {:ok, 2.1e17}
   end
 
   test "unserialize string" do
-    assert unserialize(~S(s:6:"foobar";)) == { :ok, "foobar" }
+    assert unserialize(~S(s:6:"foobar";)) == {:ok, "foobar"}
   end
 
   test "unserialize unicode string" do
-    assert unserialize(~S(s:7:"star☆";)) == { :ok, "star☆" }
+    assert unserialize(~S(s:7:"star☆";)) == {:ok, "star☆"}
   end
 
   test "unserialize string with double quote" do
-    assert unserialize(~S(s:5:"star"";)) == { :ok, ~S(star") }
+    assert unserialize(~S(s:5:"star"";)) == {:ok, ~S(star")}
   end
 
   test "unserialize array" do
-    assert unserialize("a:3:{i:0;i:4;i:1;i:5;i:2;i:6;}") == { :ok, [{0, 4}, {1, 5}, {2, 6}] }
+    assert unserialize("a:3:{i:0;i:4;i:1;i:5;i:2;i:6;}") == {:ok, [{0, 4}, {1, 5}, {2, 6}]}
   end
 
   test "unserialize array with custom order" do
-    assert unserialize("a:3:{i:2;i:4;i:3;i:5;i:4;i:6;}") == { :ok, [{2, 4}, {3, 5}, {4, 6}] }
+    assert unserialize("a:3:{i:2;i:4;i:3;i:5;i:4;i:6;}") == {:ok, [{2, 4}, {3, 5}, {4, 6}]}
   end
 
   test "unserialize array with string keys" do
-    assert unserialize(~S(a:3:{s:1:"a";i:4;s:1:"b";i:5;s:1:"c";i:6;})) == { :ok, [{"a", 4}, {"b", 5}, {"c", 6}] }
+    assert unserialize(~S(a:3:{s:1:"a";i:4;s:1:"b";i:5;s:1:"c";i:6;})) ==
+             {:ok, [{"a", 4}, {"b", 5}, {"c", 6}]}
   end
 
   test "unserialize option array_to_map" do
-    assert unserialize(~S(a:3:{s:1:"a";i:4;s:1:"b";i:5;s:1:"c";i:6;}), array_to_map: true) == { :ok, %{"a" => 4, "b" => 5, "c" => 6} }
+    assert unserialize(~S(a:3:{s:1:"a";i:4;s:1:"b";i:5;s:1:"c";i:6;}), array_to_map: true) ==
+             {:ok, %{"a" => 4, "b" => 5, "c" => 6}}
   end
 
   test "unserialize can catch error when there are some excess data" do
-    assert unserialize("N;i:0;") == { :error, "left extra characters: 'i:0;'" }
+    assert unserialize("N;i:0;") == {:error, "left extra characters: 'i:0;'"}
+  end
+
+  test "unserialize returns excess data if given the option" do
+    assert unserialize("N;", return_excess: true) == {:ok, nil, ""}
+    assert unserialize("N;i:0;", return_excess: true) == {:ok, nil, "i:0;"}
   end
 
   test "unserialize can catch exception when unserializing bad input" do
-    assert unserialize("dsfgdfgd") == { :error, "can't unserialize that string, got exception" }
+    assert unserialize("dsfgdfgd") == {:error, "can't unserialize that string, got exception"}
   end
 
   test "unserialize serializable object" do
-    assert unserialize(~S(C:3:"obj":23:{s:15:"My private data";})) == { :ok, %PhpSerializable.Class{ class: "obj", data: ~S(s:15:"My private data";)} }
+    assert unserialize(~S(C:3:"obj":23:{s:15:"My private data";})) ==
+             {:ok, %PhpSerializable.Class{class: "obj", data: ~S(s:15:"My private data";)}}
   end
 
   test "unserialize serializable class with namespace" do
-    assert unserialize(~S(C:19:"Namespace\Classname":8:{somedata})) == { :ok, %PhpSerializable.Class{ class: "Namespace\\Classname", data: "somedata"} }
+    assert unserialize(~S(C:19:"Namespace\Classname":8:{somedata})) ==
+             {:ok, %PhpSerializable.Class{class: "Namespace\\Classname", data: "somedata"}}
   end
 
   test "unserialize serializable object with namespace" do
-    assert unserialize(~S(O:14:"NameOfTheClass":2:{i:0;s:7:"country";i:1;s:2:"ZZ";}})) == {:ok, %PhpSerializable.Object{class: "NameOfTheClass", data: {[{0, "country"}, {1, "ZZ"}], "}"}}}
+    assert unserialize(~S(O:14:"NameOfTheClass":2:{i:0;s:7:"country";i:1;s:2:"ZZ";}})) ==
+             {:ok,
+              %PhpSerializable.Object{
+                class: "NameOfTheClass",
+                data: {[{0, "country"}, {1, "ZZ"}], "}"}
+              }}
   end
 
   @tag method: "serialize"
@@ -135,7 +149,7 @@ defmodule PhpSerializerTest do
   end
 
   test "serialize map" do
-    assert serialize(%{ 1 => "a", "b" => 2}) == ~S(a:2:{i:1;s:1:"a";s:1:"b";i:2;})
+    assert serialize(%{1 => "a", "b" => 2}) == ~S(a:2:{i:1;s:1:"a";s:1:"b";i:2;})
   end
 
   test "serialize array of tuples" do
@@ -151,18 +165,21 @@ defmodule PhpSerializerTest do
   end
 
   test "serialize array of tuples with string keys" do
-    assert serialize([{"a", 4}, {"b", 5}, {"c", 6}]) == ~S(a:3:{s:1:"a";i:4;s:1:"b";i:5;s:1:"c";i:6;})
+    assert serialize([{"a", 4}, {"b", 5}, {"c", 6}]) ==
+             ~S(a:3:{s:1:"a";i:4;s:1:"b";i:5;s:1:"c";i:6;})
   end
 
   test "serialize tuple" do
-    assert serialize({4,5}) == ~S(a:2:{i:0;i:4;i:1;i:5;})
+    assert serialize({4, 5}) == ~S(a:2:{i:0;i:4;i:1;i:5;})
   end
 
   test "serialize serializable Class" do
-    assert serialize(%PhpSerializable.Class{class: "NameOfTheClass", data: "somedata"}) == ~S(C:14:"NameOfTheClass":8:{somedata})
+    assert serialize(%PhpSerializable.Class{class: "NameOfTheClass", data: "somedata"}) ==
+             ~S(C:14:"NameOfTheClass":8:{somedata})
   end
 
   test "serialize serializable Object" do
-    assert serialize(%PhpSerializable.Object{class: "NameOfTheClass", data: ["somedata", 1]}) == ~S(O:14:"NameOfTheClass":2:{i:0;s:8:"somedata";i:1;i:1;}})
+    assert serialize(%PhpSerializable.Object{class: "NameOfTheClass", data: ["somedata", 1]}) ==
+             ~S(O:14:"NameOfTheClass":2:{i:0;s:8:"somedata";i:1;i:1;}})
   end
 end


### PR DESCRIPTION
This adds a new option `:return_excess` to allow being compliant with PHP's behaviour of ignoring excess data.

Fixes: #3 